### PR TITLE
feat: make v4.1 pool extensions permissioned 

### DIFF
--- a/src/hooks/ClankerHookDynamicFeeV2.sol
+++ b/src/hooks/ClankerHookDynamicFeeV2.sol
@@ -24,9 +24,12 @@ contract ClankerHookDynamicFeeV2 is ClankerHookV2, IClankerHookDynamicFee {
 
     error TickReturned(int24 tick);
 
-    constructor(address _poolManager, address _factory, address _weth)
-        ClankerHookV2(_poolManager, _factory, _weth)
-    {}
+    constructor(
+        address _poolManager,
+        address _factory,
+        address _poolExtensionAllowlist,
+        address _weth
+    ) ClankerHookV2(_poolManager, _factory, _poolExtensionAllowlist, _weth) {}
 
     function poolConfigVars(PoolId poolId) external view returns (PoolDynamicConfigVars memory) {
         return _poolConfigVars[poolId];

--- a/src/hooks/ClankerHookStaticFeeV2.sol
+++ b/src/hooks/ClankerHookStaticFeeV2.sol
@@ -12,9 +12,12 @@ contract ClankerHookStaticFeeV2 is ClankerHookV2, IClankerHookStaticFee {
     mapping(PoolId => uint24) public clankerFee;
     mapping(PoolId => uint24) public pairedFee;
 
-    constructor(address _poolManager, address _factory, address _weth)
-        ClankerHookV2(_poolManager, _factory, _weth)
-    {}
+    constructor(
+        address _poolManager,
+        address _factory,
+        address _poolExtensionAllowlist,
+        address _weth
+    ) ClankerHookV2(_poolManager, _factory, _poolExtensionAllowlist, _weth) {}
 
     function _initializeFeeData(PoolKey memory poolKey, bytes memory feeData) internal override {
         PoolStaticConfigVars memory _poolConfigVars = abi.decode(feeData, (PoolStaticConfigVars));

--- a/src/hooks/ClankerPoolExtensionAllowlist.sol
+++ b/src/hooks/ClankerPoolExtensionAllowlist.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IClankerPoolExtensionAllowlist} from "./interfaces/IClankerPoolExtensionAllowlist.sol";
+
+import {OwnerAdmins} from "../utils/OwnerAdmins.sol";
+
+contract ClankerPoolExtensionAllowlist is IClankerPoolExtensionAllowlist, OwnerAdmins {
+    mapping(address extension => bool enabled) public enabledExtensions;
+
+    constructor(address owner_) OwnerAdmins(owner_) {}
+
+    function setPoolExtension(address extension, bool enabled) external onlyOwnerOrAdmin {
+        enabledExtensions[extension] = enabled;
+        emit SetPoolExtension(extension, enabled);
+    }
+}

--- a/src/hooks/interfaces/IClankerHookV2.sol
+++ b/src/hooks/interfaces/IClankerHookV2.sol
@@ -12,6 +12,7 @@ interface IClankerHookV2 is IClankerHook {
     error MevModuleNotOperational();
     error Unauthorized();
     error OnlyFactoryPoolsCanHaveExtensions();
+    error PoolExtensionNotEnabled();
 
     event PoolExtensionSuccess(PoolId poolId);
     event PoolExtensionFailed(PoolId poolId, IPoolManager.SwapParams swapParams);

--- a/src/hooks/interfaces/IClankerPoolExtensionAllowlist.sol
+++ b/src/hooks/interfaces/IClankerPoolExtensionAllowlist.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IOwnerAdmins} from "../../interfaces/IOwnerAdmins.sol";
+
+interface IClankerPoolExtensionAllowlist is IOwnerAdmins {
+    event SetPoolExtension(address extension, bool allowed);
+
+    function setPoolExtension(address extension, bool allowed) external;
+
+    function enabledExtensions(address extension) external view returns (bool enabled);
+}


### PR DESCRIPTION
## Summary
Makes pool extensions for v4.1 permissioned in a way similar to other external contracts in the codebase:
- Clanker owner/admins can enable/disable which pool extensions can be used to launch new tokens
- Clanker owner/admins cannot disable pool extensions for pools which have already launched, we can only prevent more pools from utilizing an extension in the future

## Background
Routers are disliking the permissionless approach.

## Changes
- Created new `ClankerPoolExtensionAllowlist` which is a standalone contract for the Clanker team to enable new pool extension addresses on.
- Has the ClankerHookV2 code check that extensions are enabled during the token deployment flow, reverting if a user is trying to use a pool extension which is no longer enabled. 