### PR TITLE
feat: airdrop v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Check out our [dune dashboards](https://dune.com/clanker_protection_team) for to
 - ClankerHookStaticFeeV2: [0xb429d62f8f3bFFb98CdB9569533eA23bF0Ba28CC](https://basescan.org/address/0xb429d62f8f3bFFb98CdB9569533eA23bF0Ba28CC)
 - ClankerSniperAuctionV2: [0xebB25BB797D82CB78E1bc70406b13233c0854413](https://basescan.org/address/0xebB25BB797D82CB78E1bc70406b13233c0854413)
 - ClankerSniperUtilV2: [0xC5AA2945d52a4096b946891ef8e01668f82eB74E](https://basescan.org/address/0xC5AA2945d52a4096b946891ef8e01668f82eB74E)
+- ClankerAirdropV2: [0xf652B3610D75D81871bf96DB50825d9af28391E0](https://basescan.org/address/0xf652B3610D75D81871bf96DB50825d9af28391E0)
 
 ### Base Sepolia
 #### v4.0
@@ -57,6 +58,7 @@ Check out our [dune dashboards](https://dune.com/clanker_protection_team) for to
 - ClankerHookStaticFeeV2: [0x11b51DBC2f7F683b81CeDa83DC0078D57bA328cc](https://sepolia.basescan.org/address/0x11b51DBC2f7F683b81CeDa83DC0078D57bA328cc)
 - ClankerSniperAuctionV2: [0x8CBD6694A9DFc0eF4D1cd333e013B88E7003E10A](https://sepolia.basescan.org/address/0x8CBD6694A9DFc0eF4D1cd333e013B88E7003E10A)
 - ClankerSniperUtilV2: [0x4DC6348D38E3e199D7Ea032c8cfE4EbDe94b442A](https://sepolia.basescan.org/address/0x4DC6348D38E3e199D7Ea032c8cfE4EbDe94b442A)
+- ClankerAirdropV2: [0x5c68F1560a5913c176Fc5238038098970B567B19](https://sepolia.basescan.org/address/0x5c68F1560a5913c176Fc5238038098970B567B19)
 
 ### Unichain Mainnet
 #### v4.0
@@ -71,6 +73,8 @@ Check out our [dune dashboards](https://dune.com/clanker_protection_team) for to
 - ClankerHookStaticFee: [0xBc6e5aBDa425309c2534Bc2bC92562F5419ce8Cc](https://uniscan.xyz/address/0xBc6e5aBDa425309c2534Bc2bC92562F5419ce8Cc)
 - ClankerSniperAuctionV0: [0x78B512C5074a1084bf3b8e6cbA8a1710d2a8d0A2](https://uniscan.xyz/address/0x78B512C5074a1084bf3b8e6cbA8a1710d2a8d0A2)
 - ClankerSniperUtilV0: [0xA25e594869ddb46c33233A793E3c8b207CC719a2](https://uniscan.xyz/address/0xA25e594869ddb46c33233A793E3c8b207CC719a2)
+#### v4.1
+- ClankerAirdropV2: [0xE143f9872A33c955F23cF442BB4B1EFB3A7402A2](https://uniscan.xyz/address/0xE143f9872A33c955F23cF442BB4B1EFB3A7402A2)
 
 ### Arbitrum Mainnet
 #### v4.0
@@ -83,6 +87,8 @@ Check out our [dune dashboards](https://dune.com/clanker_protection_team) for to
 - ClankerMevTimeDelay: [0x4E35277306a83D00E13e8C8A4307C672FA31FC99](https://arbiscan.io/address/0x4E35277306a83D00E13e8C8A4307C672FA31FC99)
 - ClankerHookDynamicFee: [0xFd213BE7883db36e1049dC42f5BD6A0ec66B68cC](https://arbiscan.io/address/0xFd213BE7883db36e1049dC42f5BD6A0ec66B68cC)
 - ClankerHookStaticFee: [0xf7aC669593d2D9D01026Fa5B756DD5B4f7aAa8Cc](https://arbiscan.io/address/0xf7aC669593d2D9D01026Fa5B756DD5B4f7aAa8Cc)
+#### v4.1
+- ClankerAirdropV2: [0x8Cb6e0216e98A7ACF622DC2dD6a39F1b4FF37014](https://arbiscan.io/address/0x8Cb6e0216e98A7ACF622DC2dD6a39F1b4FF37014)
 
 
 If you'd like these contracts on another chain, [please reach out to us](https://clanker.gitbook.io/clanker-documentation/references/contact)! For superchain purposes, we need to ensure that the Clanker contracts have the same address.

--- a/src/extensions/ClankerAirdropV2.sol
+++ b/src/extensions/ClankerAirdropV2.sol
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IClanker} from "../interfaces/IClanker.sol";
+import {IClankerExtension} from "../interfaces/IClankerExtension.sol";
+import {IClankerAirdropV2} from "./interfaces/IClankerAirdropV2.sol";
+
+import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+
+import {Hashes} from "@openzeppelin/contracts/utils/cryptography/Hashes.sol";
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+contract ClankerAirdropV2 is ReentrancyGuard, IClankerAirdropV2 {
+    address public immutable factory;
+    mapping(address token => AirdropV2 airdrop) public airdrops;
+
+    uint256 public constant MIN_LOCKUP_DURATION = 1 days;
+    uint256 public constant CLAIM_EXPIRATION_INTERVAL = 14 days;
+    uint256 public constant ZERO_CLAIM_OVERWRITE_INTERVAL = 1 days;
+
+    modifier onlyFactory() {
+        if (msg.sender != factory) revert Unauthorized();
+        _;
+    }
+
+    constructor(address factory_) {
+        factory = factory_;
+    }
+
+    function receiveTokens(
+        IClanker.DeploymentConfig calldata deploymentConfig,
+        PoolKey memory,
+        address token,
+        uint256 extensionSupply,
+        uint256 extensionIndex
+    ) external payable nonReentrant onlyFactory {
+        AirdropV2ExtensionData memory airdropData = abi.decode(
+            deploymentConfig.extensionConfigs[extensionIndex].extensionData,
+            (AirdropV2ExtensionData)
+        );
+
+        // check that we don't already have an airdrop for this token
+        if (airdrops[token].merkleRoot != bytes32(0)) {
+            revert AirdropAlreadyExists();
+        }
+
+        // ensure that the msgValue is zero
+        if (deploymentConfig.extensionConfigs[extensionIndex].msgValue != 0 || msg.value != 0) {
+            revert IClankerExtension.InvalidMsgValue();
+        }
+
+        // check the vault percentage is not zero
+        if (deploymentConfig.extensionConfigs[extensionIndex].extensionBps == 0) {
+            revert InvalidAirdropPercentage();
+        }
+
+        // check that minimum lockup duration is met
+        if (airdropData.lockupDuration < MIN_LOCKUP_DURATION) {
+            revert AirdropLockupDurationTooShort();
+        }
+
+        // set the lockup, vesting, and claim end times
+        airdrops[token].lockupEndTime = block.timestamp + airdropData.lockupDuration;
+        airdrops[token].vestingEndTime =
+            block.timestamp + airdropData.lockupDuration + airdropData.vestingDuration;
+        airdrops[token].adminClaimTime = block.timestamp + airdropData.lockupDuration
+            + airdropData.vestingDuration + CLAIM_EXPIRATION_INTERVAL;
+
+        // set fields
+        airdrops[token].admin = airdropData.admin;
+        airdrops[token].merkleRoot = airdropData.merkleRoot;
+        airdrops[token].totalClaimed = 0;
+        airdrops[token].totalSupply = extensionSupply;
+
+        // pull in token
+        SafeERC20.safeTransferFrom(IERC20(token), msg.sender, address(this), extensionSupply);
+
+        emit AirdropCreated({
+            admin: airdropData.admin,
+            token: token,
+            merkleRoot: airdropData.merkleRoot,
+            supply: extensionSupply,
+            lockupDuration: airdropData.lockupDuration,
+            vestingDuration: airdropData.vestingDuration
+        });
+    }
+
+    // update the admin of the airdrop
+    function updateAdmin(address token, address newAdmin) external {
+        if (msg.sender != airdrops[token].admin) revert Unauthorized();
+        address oldAdmin = airdrops[token].admin;
+        airdrops[token].admin = newAdmin;
+
+        emit AirdropAdminUpdated(token, oldAdmin, newAdmin);
+    }
+
+    // update the merkle root of the airdrop by admin if the merkle root is zero or if
+    // the claim overwrite interval has passed without a claim
+    function updateMerkleRoot(address token, bytes32 newMerkleRoot) external {
+        AirdropV2 storage airdrop = airdrops[token];
+
+        // ensure that the msg sender is the admin
+        if (msg.sender != airdrop.admin) revert Unauthorized();
+
+        // ensure that the admin has not claimed
+        if (airdrop.adminClaimed) revert AdminClaimed();
+
+        // ensure that no claims have occurred
+        if (airdrop.totalClaimed > 0) revert AirdropClaimsOccurred();
+
+        // calculate if the zero claim overwrite interval has passed
+        bool zeroClaimOverwriteIntervalPassed =
+            block.timestamp > airdrop.lockupEndTime + ZERO_CLAIM_OVERWRITE_INTERVAL;
+
+        // can change the merkle root if it is zero or if the zero claim overwrite interval has passed
+        if (airdrop.merkleRoot != bytes32(0) && !zeroClaimOverwriteIntervalPassed) {
+            revert UpdateMerkleRootNotAllowed();
+        }
+
+        // update the merkle root
+        airdrop.merkleRoot = newMerkleRoot;
+
+        emit AirdropMerkleRootUpdated(token, airdrop.merkleRoot, newMerkleRoot);
+    }
+
+    // admins can claim the remaining balance after the claim expiration interval
+    // has been hit
+    function adminClaim(address token, address recipient) external {
+        AirdropV2 storage airdrop = airdrops[token];
+        if (msg.sender != airdrop.admin) revert Unauthorized();
+        if (block.timestamp < airdrop.adminClaimTime) revert ClaimNotEnded();
+        if (airdrop.adminClaimed) revert AdminClaimed();
+
+        // update the admin claimed flag
+        airdrop.adminClaimed = true;
+
+        // transfer the remaining balance to the recipient
+        SafeERC20.safeTransfer(IERC20(token), recipient, airdrop.totalSupply - airdrop.totalClaimed);
+
+        emit AirdropAdminClaimed(token, airdrop.totalSupply - airdrop.totalClaimed);
+    }
+
+    function claim(
+        address token,
+        address recipient,
+        uint256 allocatedAmount,
+        bytes32[] calldata proof
+    ) external nonReentrant {
+        AirdropV2 storage airdrop = airdrops[token];
+
+        // check that the airdrop exists
+        if (airdrop.merkleRoot == bytes32(0)) {
+            revert AirdropNotCreated();
+        }
+
+        // check if the admin has claimed
+        if (airdrop.adminClaimed) revert AdminClaimed();
+
+        // check that the lockup period has passed
+        if (block.timestamp < airdrop.lockupEndTime) {
+            revert AirdropNotUnlocked();
+        }
+
+        // check that the allocated amount is not zero
+        if (allocatedAmount == 0) {
+            revert ZeroClaim();
+        }
+
+        // check that the max claim amount has not been exceeded
+        if (airdrop.totalClaimed >= airdrop.totalSupply) {
+            revert TotalMaxClaimed();
+        }
+
+        // verify proof
+        if (
+            !MerkleProof.verifyCalldata(
+                proof,
+                airdrop.merkleRoot,
+                keccak256(bytes.concat(keccak256(abi.encode(recipient, allocatedAmount))))
+            )
+        ) {
+            revert InvalidProof();
+        }
+
+        // calculate amount available to claim
+        uint256 amountClaimed = airdrop.amountClaimed[recipient];
+        if (amountClaimed >= allocatedAmount) {
+            revert UserMaxClaimed();
+        }
+
+        // get total available amount unlocked
+        uint256 claimableAmount = _getAmountClaimable(token, allocatedAmount, amountClaimed);
+
+        // modulate down the amount available to claim if greater than available supply
+        if (airdrop.totalClaimed + claimableAmount >= airdrop.totalSupply) {
+            claimableAmount = airdrop.totalSupply - airdrop.totalClaimed;
+        }
+
+        if (claimableAmount == 0) {
+            revert ZeroToClaim();
+        }
+
+        // update claimed amounts
+        airdrop.amountClaimed[recipient] += claimableAmount;
+        airdrop.totalClaimed += claimableAmount;
+
+        // transfer tokens
+        SafeERC20.safeTransfer(IERC20(token), recipient, claimableAmount);
+
+        emit AirdropClaimed(
+            token,
+            recipient,
+            airdrop.amountClaimed[recipient],
+            allocatedAmount - airdrop.amountClaimed[recipient]
+        );
+    }
+
+    // helper function to surface the amount available to claim for a user,
+    // assuming that there exists a proof for the allocated amount
+    function amountAvailableToClaim(address token, address recipient, uint256 allocatedAmount)
+        external
+        view
+        returns (uint256)
+    {
+        if (airdrops[token].merkleRoot == bytes32(0)) {
+            revert AirdropNotCreated();
+        }
+
+        // check if the admin has claimed
+        if (airdrops[token].adminClaimed) revert AdminClaimed();
+
+        if (block.timestamp < airdrops[token].lockupEndTime) return 0;
+
+        return _getAmountClaimable(token, allocatedAmount, airdrops[token].amountClaimed[recipient]);
+    }
+
+    function _getAmountClaimable(address token, uint256 allocatedAmount, uint256 totalUserClaimed)
+        internal
+        view
+        returns (uint256)
+    {
+        if (block.timestamp >= airdrops[token].vestingEndTime) {
+            // if the vesting period has passed, withdraw the remaining balance
+            return allocatedAmount - totalUserClaimed;
+        } else {
+            // if the vesting period has not passed, calculate the amount to withdraw based on the
+            // vesting period and how much has already been withdrawn
+            uint256 totalAmountAvailable = allocatedAmount
+                * (block.timestamp - airdrops[token].lockupEndTime)
+                / (airdrops[token].vestingEndTime - airdrops[token].lockupEndTime);
+
+            return totalAmountAvailable - totalUserClaimed;
+        }
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == type(IClankerExtension).interfaceId;
+    }
+}

--- a/src/extensions/interfaces/IClankerAirdropV2.sol
+++ b/src/extensions/interfaces/IClankerAirdropV2.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IClankerExtension} from "../../interfaces/IClankerExtension.sol";
+
+interface IClankerAirdropV2 is IClankerExtension {
+    struct AirdropV2ExtensionData {
+        address admin;
+        bytes32 merkleRoot;
+        uint256 lockupDuration;
+        uint256 vestingDuration;
+    }
+
+    struct AirdropV2 {
+        address admin; // admin of the airdrop
+        bytes32 merkleRoot; // merkle root of the airdrop
+        uint256 totalSupply; // total supply of the airdrop
+        uint256 totalClaimed; // total amount claimed so far
+        uint256 lockupEndTime; // when the lockup period ends
+        uint256 vestingEndTime; // when the vesting period ends
+        uint256 adminClaimTime; // when the owner can claim the remaining balance
+        bool adminClaimed; // if the admin has claimed the remaining balance
+        mapping(address => uint256) amountClaimed; // amount claimed by each recipient so far
+    }
+
+    error InvalidAirdropPercentage();
+    error Unauthorized();
+    error InvalidProof();
+    error TotalMaxClaimed();
+    error UserMaxClaimed();
+    error ZeroClaim();
+    error ZeroToClaim();
+    error AirdropNotUnlocked();
+    error AirdropAlreadyExists();
+    error AirdropLockupDurationTooShort();
+    error AirdropNotCreated();
+    error AirdropClaimsOccurred();
+    error UpdateMerkleRootNotAllowed();
+    error AdminClaimed();
+    error ClaimNotEnded();
+
+    event AirdropMerkleRootUpdated(
+        address indexed token, bytes32 oldMerkleRoot, bytes32 newMerkleRoot
+    );
+
+    event AirdropCreated(
+        address indexed token,
+        address indexed admin,
+        bytes32 merkleRoot,
+        uint256 supply,
+        uint256 lockupDuration,
+        uint256 vestingDuration
+    );
+    event AirdropClaimed(
+        address indexed token,
+        address indexed user,
+        uint256 totalUserAmountClaimed,
+        uint256 userAmountStillLocked
+    );
+    event AirdropAdminUpdated(
+        address indexed token, address indexed oldAdmin, address indexed newAdmin
+    );
+    event AirdropAdminClaimed(address indexed token, uint256 amount);
+
+    function claim(
+        address token,
+        address recipient,
+        uint256 allocatedAmount,
+        bytes32[] calldata proof
+    ) external;
+
+    function amountAvailableToClaim(address token, address recipient, uint256 allocatedAmount)
+        external
+        view
+        returns (uint256);
+}


### PR DESCRIPTION
## Summary 
This extension upgrade enables greater admin capabilities for airdrops.

## Background

Issues our users have faced with the ClankerAirdrop contract:
- desire to recover unclaimed user tokens after a period of time
- setting incorrect merkle root at token launch
- desire to set merkle root later in a token's lifetime

## Changes
This ClankerAirdropV2 upgrade enables:
- deployers to set an admin for a token's airdropped supply at launch
- enables the merkle root to be zero on launch (previously this would've reverted)
- enables a token's admin to change the merkle root if it is zero or if it is 24 hours past the end of the lockup period and no claims have occured
- enables a token's admin to change the token's admin
- enables the token's admin to recover unclaimed supply 14 days after the lock up + vesting period has ended

See docs [here](https://clanker.gitbook.io/clanker-documentation/references/core-contracts/v4/extensions/clankerairdropv2).